### PR TITLE
dgenomes: subdataset for bioinformatics

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -121,3 +121,8 @@
 	path = neuralensemble
 	url = ./neuralensemble
 	datalad-id = 54ef79b6-422d-4261-ae23-a8dcd9fd8d31
+[submodule "dgenomes"]
+	path = dgenomes
+	url = https://github.com/apraga/dgenomes
+	datalad-id = e61c685b-54f3-4a0c-885a-b17ad5c6ee36
+	datalad-url = https://github.com/apraga/dgenomes


### PR DESCRIPTION
Hi,


## Context
For bioinformatics, there is a pressing need to have a centralized resources for databases needed for the different pipelines. Existing data is already availaible of public website (FTW, AWS...) but without a central hub.
Datalad could fill this gap.

This PR is useful for germline human analysis and offer major publicly available databases : human genomes and clinical database for variant annotation.

## Technical details
I've chose to simply mirror existing resources without renaming them for the sake of simpliclity. Also, several files are archive and must be decompressed.

To try to follow YODA principles, this is a metadataset, with a subdataset for each database. Each of this subdataset have a branch for major genome versions to be able to switch between them. At the moment, only the current genome version is implememented (GRCh38) but I plan to add T2T support as a separate branch.

## Possible improvements
- Database versions are stored in git commit messages. Using a custom extractor from the data itself or the URL would be better


This is a draft PR to check it suits integration into datalad main datasets. I will test it into production if the content and layout fit the project :)


Thanks,